### PR TITLE
Fix hero visibility: planets not hidden by dark overlays

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -40,7 +40,7 @@ export default function HomePage() {
           className="absolute inset-0 pointer-events-none"
           style={{
             background:
-              'radial-gradient(ellipse 80% 80% at 50% 50%, transparent 30%, rgba(10,10,10,0.85) 100%)',
+              'radial-gradient(ellipse 82% 82% at 50% 50%, transparent 45%, rgba(10,10,10,0.58) 100%)',
           }}
         />
         <div className="absolute bottom-0 left-0 right-0 h-64 bg-gradient-to-t from-brand-black to-transparent pointer-events-none" />

--- a/src/components/HeroScene.tsx
+++ b/src/components/HeroScene.tsx
@@ -21,7 +21,7 @@ function FallbackPlanets() {
       <div className="absolute -top-24 -left-24 w-[420px] h-[420px] rounded-full opacity-40 blur-2xl animate-pulse" style={{ background: 'radial-gradient(circle, rgba(201,168,76,0.55) 0%, rgba(201,168,76,0.05) 55%, transparent 75%)' }} />
       <div className="absolute top-[16%] right-[8%] w-[280px] h-[280px] rounded-full opacity-35 blur-xl animate-pulse" style={{ animationDelay: '400ms', background: 'radial-gradient(circle, rgba(107,79,26,0.7) 0%, rgba(107,79,26,0.08) 55%, transparent 75%)' }} />
       <div className="absolute bottom-[8%] left-[22%] w-[220px] h-[220px] rounded-full opacity-30 blur-xl animate-pulse" style={{ animationDelay: '900ms', background: 'radial-gradient(circle, rgba(6,182,212,0.38) 0%, rgba(6,182,212,0.06) 55%, transparent 75%)' }} />
-      <div className="absolute inset-0" style={{ background: 'radial-gradient(ellipse at center, rgba(26,10,46,0.08) 0%, rgba(10,10,10,0.62) 82%)' }} />
+      <div className="absolute inset-0" style={{ background: 'radial-gradient(ellipse at center, rgba(26,10,46,0.05) 0%, rgba(10,10,10,0.42) 82%)' }} />
     </div>
   );
 }


### PR DESCRIPTION
Reduce vignette and fallback dark overlays so planets/scene remain visible in hero.