### PR TITLE
🎨 Palette: Add accessibility attributes to Navigation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-03-12 - [Nav ARIA attributes]
+**Learning:** `aria-current` needs to be placed on the interactive element (`<Link>`), not on a decorative child element (`<span>`).
+**Action:** When adding accessibility attributes to a link with complex inner DOM, ensure the ARIA attribute is on the `<a>` or `<Link>` element itself.

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -56,6 +56,7 @@ export function Nav() {
                   ? 'text-brand-gold'
                   : 'text-brand-gray-300 hover:text-brand-white'
               }`}
+              aria-current={pathname === href || pathname.startsWith(href + '/') ? 'page' : undefined}
             >
               {label}
               <span
@@ -74,6 +75,8 @@ export function Nav() {
           className="md:hidden flex flex-col gap-1.5 w-6 py-1 group"
           onClick={() => setMenuOpen(!menuOpen)}
           aria-label={menuOpen ? 'Close menu' : 'Open menu'}
+          aria-expanded={menuOpen}
+          aria-controls="mobile-menu"
         >
           <span
             className={`block h-px bg-brand-white transition-all duration-300 origin-center ${
@@ -102,6 +105,7 @@ export function Nav() {
             exit={{ opacity: 0, y: -8 }}
             transition={{ duration: 0.3, ease: [0.16, 1, 0.3, 1] }}
             className="fixed inset-0 z-40 bg-brand-black/95 backdrop-blur-xl flex flex-col items-center justify-center gap-10 md:hidden"
+            id="mobile-menu"
           >
             {links.map(({ href, label }, i) => (
               <motion.div
@@ -115,6 +119,7 @@ export function Nav() {
                   className={`text-4xl font-light transition-colors duration-300 ${
                     pathname === href ? 'text-brand-gold' : 'text-brand-white hover:text-brand-gold'
                   }`}
+                  aria-current={pathname === href ? 'page' : undefined}
                 >
                   {label}
                 </Link>


### PR DESCRIPTION
💡 What: Added `aria-current`, `aria-expanded`, and `aria-controls` to the main navigation menu. Added `id="mobile-menu"` to the mobile menu.
🎯 Why: To improve screen reader experience by making the current active page and mobile menu state clear.
♿ Accessibility:
- Active page links now have `aria-current="page"`
- Mobile menu button has `aria-expanded` and `aria-controls`
- Mobile menu has corresponding `id`

---
*PR created automatically by Jules for task [255891583945682510](https://jules.google.com/task/255891583945682510) started by @wanda-OS-dev*