### PR TITLE
🎨 Palette: Improve mobile menu accessibility and keyboard support

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Full-screen Mobile Menu Accessibility
+**Learning:** Full-screen mobile menus should be treated as modal dialogs to prevent screen readers from reading background content while the menu is open.
+**Action:** When implementing full-screen overlay menus, always add `role="dialog"`, `aria-modal="true"`, an appropriate `aria-label`, and ensure the menu can be closed via the `Escape` key. Also, explicitly link the trigger button to the menu using `aria-controls` and communicate its state with `aria-expanded`.

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -27,6 +27,17 @@ export function Nav() {
     setMenuOpen(false);
   }, [pathname]);
 
+  // Close menu on escape key
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && menuOpen) {
+        setMenuOpen(false);
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [menuOpen]);
+
   return (
     <>
       <motion.header
@@ -73,6 +84,8 @@ export function Nav() {
         <button
           className="md:hidden flex flex-col gap-1.5 w-6 py-1 group"
           onClick={() => setMenuOpen(!menuOpen)}
+          aria-expanded={menuOpen}
+          aria-controls="mobile-menu"
           aria-label={menuOpen ? 'Close menu' : 'Open menu'}
         >
           <span
@@ -97,6 +110,10 @@ export function Nav() {
       <AnimatePresence>
         {menuOpen && (
           <motion.div
+            id="mobile-menu"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Mobile navigation menu"
             initial={{ opacity: 0, y: -8 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -8 }}


### PR DESCRIPTION
💡 **What:** Added comprehensive accessibility support to the mobile navigation menu.
- Added `aria-expanded`, `aria-controls` to the trigger button.
- Added `id="mobile-menu"`, `role="dialog"`, `aria-modal="true"`, and `aria-label` to the menu container.
- Added support for closing the menu via the `Escape` key.
- Documented this learning pattern in `.jules/palette.md`.

🎯 **Why:** Full-screen mobile menus should behave as modal dialogs. Without these attributes, screen readers may read the background content underneath the menu, causing confusion. The escape key support allows keyboard-only users to dismiss the menu naturally.

♿ **Accessibility:** Improvements target screen reader context and keyboard navigation, ensuring WCAG compliance for modal overlays.

---
*PR created automatically by Jules for task [7300866006599617379](https://jules.google.com/task/7300866006599617379) started by @wanda-OS-dev*