### PR TITLE
⚡ Bolt: Optimize static array derivations using useMemo

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-03-17 - [Avoid redundant derivative array calculations on static data]
+**Learning:** In React components dealing with static data (like hardcoded or imported arrays), performing operations like `Array.prototype.slice` or mapping during render cycles generates redundant calculations and new array references, which can lead to unnecessary re-renders in child components.
+**Action:** Always prefer `useMemo` to pre-calculate derivative arrays (e.g., truncated tags) once per data item. This avoids redundant operations on every render.

--- a/src/app/work/page.tsx
+++ b/src/app/work/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import React, { useMemo } from 'react';
 import { motion } from 'framer-motion';
 import Link from 'next/link';
 import { projects } from '@/lib/projects';
@@ -30,6 +31,14 @@ function getCategoryStyle(category: string) {
 }
 
 export default function WorkPage() {
+  // Pre-calculate truncated tags once to avoid redundant slice() operations during render cycles
+  const displayProjects = useMemo(() => {
+    return projects.map((project) => ({
+      ...project,
+      displayTags: project.tags.slice(0, 4),
+    }));
+  }, []);
+
   return (
     <div
       className="min-h-screen pt-32 pb-24 relative overflow-hidden"
@@ -94,7 +103,7 @@ export default function WorkPage() {
           animate="show"
           className="grid grid-cols-1 md:grid-cols-2 gap-5"
         >
-          {projects.map((project) => {
+          {displayProjects.map((project) => {
             const catStyle = getCategoryStyle(project.category);
             return (
               <motion.div key={project.id} variants={item}>
@@ -200,7 +209,7 @@ export default function WorkPage() {
 
                     {/* Tags */}
                     <div className="flex flex-wrap gap-1.5 mb-6">
-                      {project.tags.slice(0, 4).map((tag) => (
+                      {project.displayTags.map((tag) => (
                         <span
                           key={tag}
                           className="text-xs text-brand-gray-500 px-2 py-0.5 rounded-sm"


### PR DESCRIPTION
💡 What: Implemented a `useMemo` optimization in `src/app/work/page.tsx` to pre-calculate derivative static arrays (specifically, the `slice(0, 4)` operation on project tags).

🎯 Why: During render cycles, performing `slice(0, 4)` inside a map generates redundant calculations. By moving this into a `useMemo` block, the derived array is calculated exactly once when the component mounts.

📊 Impact: Reduces array allocations and redundant operations during re-renders. Since `projects` is static data, the sliced array is cached and never recalculated.

🔬 Measurement: Verify by loading `/work` path. Visuals should be completely unaffected. Performance profiles would show fewer allocations in standard use cases.

---
*PR created automatically by Jules for task [10516774320648786589](https://jules.google.com/task/10516774320648786589) started by @wanda-OS-dev*