### PR TITLE
🎨 Palette: Contact Form Accessibility Improvements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Form Accessibility Enhancements
+**Learning:** Next.js static exports (`output: export`) may behave inconsistently with trailing slashes locally vs. deployed. Direct HTML access (`/contact.html`) is required for robust local Playwright testing when serving via `serve out`.
+**Action:** When working on form accessibility components (like visual required markers and dynamic `aria-live` feedback), explicitly append `.html` to URLs during local validation scripts to prevent hydration timeouts.

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -86,7 +86,7 @@ export default function ContactPage() {
             transition={{ delay: 0.15, duration: 0.8, ease: [0.16, 1, 0.3, 1] }}
           >
             {state === 'success' ? (
-              <div className="flex flex-col items-center justify-center h-full py-16 text-center">
+              <div className="flex flex-col items-center justify-center h-full py-16 text-center" aria-live="polite">
                 <div className="w-12 h-12 rounded-full border border-brand-gold flex items-center justify-center mb-6">
                   <svg width="20" height="20" fill="none" viewBox="0 0 20 20">
                     <path
@@ -106,7 +106,7 @@ export default function ContactPage() {
                 {/* Name */}
                 <div>
                   <label htmlFor="name" className="text-xs font-medium tracking-widest uppercase text-brand-gray-500 block mb-2">
-                    Name
+                    Name<span aria-hidden="true" className="text-brand-gold ml-1">*</span>
                   </label>
                   <input
                     id="name"
@@ -121,7 +121,7 @@ export default function ContactPage() {
                 {/* Email */}
                 <div>
                   <label htmlFor="email" className="text-xs font-medium tracking-widest uppercase text-brand-gray-500 block mb-2">
-                    Email
+                    Email<span aria-hidden="true" className="text-brand-gold ml-1">*</span>
                   </label>
                   <input
                     id="email"
@@ -136,7 +136,7 @@ export default function ContactPage() {
                 {/* Message */}
                 <div>
                   <label htmlFor="message" className="text-xs font-medium tracking-widest uppercase text-brand-gray-500 block mb-2">
-                    Message
+                    Message<span aria-hidden="true" className="text-brand-gold ml-1">*</span>
                   </label>
                   <textarea
                     id="message"
@@ -150,13 +150,14 @@ export default function ContactPage() {
 
                 {/* Error */}
                 {state === 'error' && (
-                  <p className="text-red-400 text-sm">{errorMsg}</p>
+                  <p className="text-red-400 text-sm" role="alert" aria-live="assertive">{errorMsg}</p>
                 )}
 
                 {/* Submit */}
                 <button
                   type="submit"
                   disabled={state === 'sending'}
+                  aria-disabled={state === 'sending'}
                   className="w-full bg-brand-gold text-brand-black font-medium text-sm py-3.5 rounded-sm hover:bg-brand-gold-muted transition-colors duration-300 disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   {state === 'sending' ? 'Sending...' : 'Send Message'}


### PR DESCRIPTION
**🎨 Palette: Contact Form Accessibility Improvements**

**💡 What:** 
Added visual required indicators (`*`) to the contact form fields and introduced dynamic ARIA live regions for form submission feedback (success and error states). Also initialized the Palette journal with critical learnings regarding local Playwright testing of Next.js static exports.

**🎯 Why:** 
The inputs were marked as `required`, but there was no visual indication for users until they tried to submit. Additionally, while the form state changed visually upon submission (success message or error text), this feedback was not automatically announced to screen reader users, leaving them unaware of the outcome.

**📸 Before/After:** 
Visible asterisks (`*`) in brand gold color are now present next to the "Name", "Email", and "Message" labels.

**♿ Accessibility:** 
- **Visual Cues:** Required asterisks added with `aria-hidden="true"` so they don't redundantly announce "asterisk" to screen readers (since the native `required` attribute already handles the announcement).
- **Dynamic Announcements:** The success message container now uses `aria-live="polite"` to gently announce successful submission. The error message uses `role="alert"` and `aria-live="assertive"` to immediately interrupt the screen reader and announce the failure.

---
*PR created automatically by Jules for task [3109780290268986439](https://jules.google.com/task/3109780290268986439) started by @wanda-OS-dev*