### PR TITLE
🛡️ Sentinel: [HIGH] Fix HTML Injection in contact email

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-20 - [HTML Injection in Nodemailer]
+**Vulnerability:** Unsanitized user inputs (`name`, `email`, `message`) were being directly interpolated into the HTML body of emails sent via `nodemailer`.
+**Learning:** `nodemailer` does not automatically sanitize user-controlled variables in HTML email bodies, leading to potential HTML injection or Cross-Site Scripting (XSS) if the receiving email client executes scripts or renders malicious HTML.
+**Prevention:** Always manually escape or sanitize user-controlled inputs before injecting them into HTML contexts, even when using well-known libraries like `nodemailer`. Create and use a local `escapeHtml` helper.

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -17,6 +17,15 @@ function rateLimit(ip: string): boolean {
   return true;
 }
 
+function escapeHtml(unsafe: string): string {
+  return unsafe
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
 export async function POST(req: NextRequest) {
   const ip = req.headers.get('x-forwarded-for') ?? 'unknown';
 
@@ -58,7 +67,7 @@ export async function POST(req: NextRequest) {
         to: CONTACT_EMAIL,
         subject: `New message from ${name}`,
         text: `Name: ${name}\nEmail: ${email}\n\n${message}`,
-        html: `<p><strong>Name:</strong> ${name}</p><p><strong>Email:</strong> ${email}</p><p>${message.replace(/\n/g, '<br/>')}</p>`,
+        html: `<p><strong>Name:</strong> ${escapeHtml(name)}</p><p><strong>Email:</strong> ${escapeHtml(email)}</p><p>${escapeHtml(message).replace(/\n/g, '<br/>')}</p>`,
       });
     } catch (err) {
       console.error('[contact] email send failed:', err);


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: User-controlled fields (`name`, `email`, `message`) in `src/app/api/contact/route.ts` were unescaped when being rendered into the HTML email template through `nodemailer`, which does not perform automatic input sanitization for you. This allows malicious actors to perform HTML injection and cross-site scripting attacks via emails.
🎯 Impact: This could be exploited by injecting XSS scripts or malformed HTML payloads. Given `nodemailer` creates valid mail components based on user input, it acts as a vector for client-side execution, bypassing conventional CSRF boundaries since it triggers immediately via mail render.
🔧 Fix: We manually added an `escapeHtml` util block into the route handler, and explicitly bound it on user fields within the template strings payload. We also documented this behavior under `.jules/sentinel.md`.
✅ Verification: `escapeHtml` returns the equivalent valid string text of unsafe inputs via `.replace`. We ran `pnpm build` to compile successfully against this patch.

---
*PR created automatically by Jules for task [2660183029823931079](https://jules.google.com/task/2660183029823931079) started by @wanda-OS-dev*