### PR TITLE
🎨 Palette: Improve contact form accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-03-21 - [A11y Enhancements]
+**Learning:** Adding screen reader live regions (`aria-live="polite"`, `role="status"` for success; `aria-live="assertive"`, `role="alert"` for errors) so that form submission results are correctly announced to assistive technologies. It also adds a visual asterisk (`*`) to the form labels, fulfilling the specific "missing 'required' indicators on form fields" objective from the prompt.
+**Action:** Consistently use `aria-live="polite"` for success states, `aria-live="assertive"` with `role="alert"` for errors, and ensure required fields have visual cues accompanied by `aria-hidden="true"` to complement HTML5 `required` attributes.

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -86,7 +86,7 @@ export default function ContactPage() {
             transition={{ delay: 0.15, duration: 0.8, ease: [0.16, 1, 0.3, 1] }}
           >
             {state === 'success' ? (
-              <div className="flex flex-col items-center justify-center h-full py-16 text-center">
+              <div aria-live="polite" role="status" className="flex flex-col items-center justify-center h-full py-16 text-center">
                 <div className="w-12 h-12 rounded-full border border-brand-gold flex items-center justify-center mb-6">
                   <svg width="20" height="20" fill="none" viewBox="0 0 20 20">
                     <path
@@ -106,7 +106,7 @@ export default function ContactPage() {
                 {/* Name */}
                 <div>
                   <label htmlFor="name" className="text-xs font-medium tracking-widest uppercase text-brand-gray-500 block mb-2">
-                    Name
+                    Name<span aria-hidden="true" className="text-brand-gold ml-1">*</span>
                   </label>
                   <input
                     id="name"
@@ -121,7 +121,7 @@ export default function ContactPage() {
                 {/* Email */}
                 <div>
                   <label htmlFor="email" className="text-xs font-medium tracking-widest uppercase text-brand-gray-500 block mb-2">
-                    Email
+                    Email<span aria-hidden="true" className="text-brand-gold ml-1">*</span>
                   </label>
                   <input
                     id="email"
@@ -136,7 +136,7 @@ export default function ContactPage() {
                 {/* Message */}
                 <div>
                   <label htmlFor="message" className="text-xs font-medium tracking-widest uppercase text-brand-gray-500 block mb-2">
-                    Message
+                    Message<span aria-hidden="true" className="text-brand-gold ml-1">*</span>
                   </label>
                   <textarea
                     id="message"
@@ -150,7 +150,7 @@ export default function ContactPage() {
 
                 {/* Error */}
                 {state === 'error' && (
-                  <p className="text-red-400 text-sm">{errorMsg}</p>
+                  <p aria-live="assertive" role="alert" className="text-red-400 text-sm">{errorMsg}</p>
                 )}
 
                 {/* Submit */}


### PR DESCRIPTION
💡 **What:** Added `aria-live` and `role` attributes to the success and error states in the contact form, and added visual asterisks (`*`) to the required fields.
🎯 **Why:** To ensure screen readers announce the success or failure of a form submission to assistive technologies, and to clarify to sighted users which fields are mandatory.
📸 **Before/After:** The success and error states now communicate with screen readers, and the form labels visually show an asterisk.
♿ **Accessibility:** Form fields now clearly denote required status (with the asterisk hidden from screen readers via `aria-hidden`), and dynamic success/error updates are now correctly announced using live regions (`polite` and `assertive`).

---
*PR created automatically by Jules for task [13000329169509593382](https://jules.google.com/task/13000329169509593382) started by @wanda-OS-dev*