### PR TITLE
🧹 [Code Health] Remove unused 'link' property from Project interface

### DIFF
--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -8,7 +8,6 @@ export interface Project {
   tags: string[];
   accentColor: string;
   outcome?: string;
-  link?: string;
 }
 
 export const projects: Project[] = [


### PR DESCRIPTION
🎯 **What:** Removed the unused `link` property from the `Project` interface.
💡 **Why:** The `link` property was defined as optional but never used in any of the static project instances, nor was it referenced in the rendering logic for any of the project components. Removing dead code reduces cognitive load and improves maintainability by accurately reflecting the actual data structure utilized in the application.
✅ **Verification:** Performed a global search for usages of `link` across the codebase which confirmed it was not actively used by any mapping, rendering, or routing paths. `node_modules` was missing in this environment but manual static analysis confirmed the removal has zero side effects since the property was never assigned.
✨ **Result:** The `Project` interface perfectly mirrors the provided project items, resolving the dead code code health issue securely.

---
*PR created automatically by Jules for task [16490389816500607812](https://jules.google.com/task/16490389816500607812) started by @wanda-OS-dev*