### PR TITLE
🧹 [code health improvement] extract THREE.Color into module constant

### DIFF
--- a/src/components/HeroScene.tsx
+++ b/src/components/HeroScene.tsx
@@ -5,6 +5,8 @@ import { Canvas, useFrame } from '@react-three/fiber';
 import { Float, MeshTransmissionMaterial, Environment } from '@react-three/drei';
 import * as THREE from 'three';
 
+const BACKGROUND_COLOR = new THREE.Color('#0a0a0a');
+
 function supportsWebGL(): boolean {
   try {
     const canvas = document.createElement('canvas');
@@ -47,7 +49,7 @@ function FloatingOrb({ position, scale = 1 }: { position: [number, number, numbe
           ior={1.4}
           chromaticAberration={0.04}
           color="#c9a84c"
-          background={new THREE.Color('#0a0a0a')}
+          background={BACKGROUND_COLOR}
         />
       </mesh>
     </Float>


### PR DESCRIPTION
🎯 **What:** Extracted `new THREE.Color('#0a0a0a')` from the `<MeshTransmissionMaterial>` background prop inside `FloatingOrb` into a module-level constant (`BACKGROUND_COLOR`).
💡 **Why:** Instantiating `new THREE.Color` directly in the JSX causes memory allocation on every render frame, which could add up to significant garbage collection pressure, especially when the component contains `useFrame` that fires 60 times a second. Moving it to the module level ensures it is allocated only once.
✅ **Verification:** Ran `pnpm build` to ensure the project still type-checks and compiles properly. Ran a local automated code review which validated the change.
✨ **Result:** `FloatingOrb` no longer instantiates unnecessary objects on every render cycle. Performance and readability are improved without changing visual behavior.

---
*PR created automatically by Jules for task [18280463407395099643](https://jules.google.com/task/18280463407395099643) started by @wanda-OS-dev*