### PR TITLE
🧹 [code health] Remove duplicate `@types/nodemailer` devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,13 +21,12 @@
   },
   "devDependencies": {
     "@types/node": "^20.14.12",
-    "@types/nodemailer": "^7.0.11",
+    "@types/nodemailer": "^6.4.15",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "autoprefixer": "^10.4.19",
     "eslint": "^8.57.0",
     "eslint-config-next": "14.2.5",
-    "@types/nodemailer": "^6.4.15",
     "postcss": "^8.4.40",
     "tailwindcss": "^3.4.7",
     "typescript": "^5.5.4"


### PR DESCRIPTION
🎯 **What:** Removed duplicate `@types/nodemailer` declaration in `package.json`.
💡 **Why:** Having multiple versions listed (`^7.0.11` and `^6.4.15`) causes resolution conflicts and confusion. We kept the `^6.4.15` one and sorted the list alphabetically for better maintainability.
✅ **Verification:** Verified by running `pnpm build` which succeeded, making sure there were no type check errors for `nodemailer` usages.
✨ **Result:** Improved package list readability, and more predictable dependency resolutions.

---
*PR created automatically by Jules for task [8208614331924432996](https://jules.google.com/task/8208614331924432996) started by @wanda-OS-dev*