### PR TITLE
🧹 Extract duplicated ArrowRightIcon SVG into shared component

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from 'framer-motion';
 import Link from 'next/link';
+import { ArrowRightIcon } from '@/components/icons/ArrowRightIcon';
 
 const skills = [
   { category: 'AI & Automation', items: ['Multi-Agent Systems', 'LLM Orchestration', 'OpenAI / Anthropic', 'Autonomous Workflows', 'RAG Pipelines'] },
@@ -140,15 +141,7 @@ export default function AboutPage() {
               className="flex-shrink-0 inline-flex items-center gap-2 bg-brand-gold text-brand-black font-medium text-sm px-7 py-3.5 rounded-sm hover:bg-brand-gold-muted transition-colors duration-300"
             >
               Start a conversation
-              <svg width="14" height="14" fill="none" viewBox="0 0 14 14">
-                <path
-                  d="M1 7h12M8 2l5 5-5 5"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
+              <ArrowRightIcon />
             </Link>
           </div>
         </motion.div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import { motion } from 'framer-motion';
 import Link from 'next/link';
 import dynamic from 'next/dynamic';
 import { projects } from '@/lib/projects';
+import { ArrowRightIcon } from '@/components/icons/ArrowRightIcon';
 
 // Dynamic import to avoid SSR issues with WebGL
 const HeroScene = dynamic(
@@ -92,15 +93,7 @@ export default function HomePage() {
                 className="inline-flex items-center gap-2 bg-brand-gold text-brand-black font-medium text-sm px-7 py-3.5 rounded-sm hover:bg-brand-gold-muted transition-colors duration-300"
               >
                 View Work
-                <svg width="14" height="14" fill="none" viewBox="0 0 14 14">
-                  <path
-                    d="M1 7h12M8 2l5 5-5 5"
-                    stroke="currentColor"
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                </svg>
+                <ArrowRightIcon />
               </Link>
               <Link
                 href="/contact"
@@ -168,9 +161,7 @@ export default function HomePage() {
                 className="inline-flex items-center gap-2 text-brand-gold text-sm hover:gap-4 transition-all duration-300"
               >
                 More about me
-                <svg width="14" height="14" fill="none" viewBox="0 0 14 14">
-                  <path d="M1 7h12M8 2l5 5-5 5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-                </svg>
+                <ArrowRightIcon />
               </Link>
             </motion.div>
 
@@ -246,9 +237,7 @@ export default function HomePage() {
               className="hidden md:inline-flex items-center gap-2 text-brand-gray-500 hover:text-brand-white text-sm transition-colors duration-300"
             >
               All projects
-              <svg width="14" height="14" fill="none" viewBox="0 0 14 14">
-                <path d="M1 7h12M8 2l5 5-5 5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-              </svg>
+              <ArrowRightIcon />
             </Link>
           </motion.div>
 
@@ -347,9 +336,7 @@ export default function HomePage() {
               className="inline-flex items-center gap-2 text-brand-gray-500 hover:text-brand-white text-sm transition-colors duration-300"
             >
               All projects
-              <svg width="14" height="14" fill="none" viewBox="0 0 14 14">
-                <path d="M1 7h12M8 2l5 5-5 5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-              </svg>
+              <ArrowRightIcon />
             </Link>
           </motion.div>
         </div>
@@ -384,9 +371,7 @@ export default function HomePage() {
               className="inline-flex items-center gap-2 bg-brand-gold text-brand-black font-medium text-sm px-8 py-4 rounded-sm hover:bg-brand-gold-muted transition-colors duration-300"
             >
               Start a conversation
-              <svg width="14" height="14" fill="none" viewBox="0 0 14 14">
-                <path d="M1 7h12M8 2l5 5-5 5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-              </svg>
+              <ArrowRightIcon />
             </Link>
           </motion.div>
         </div>

--- a/src/app/work/page.tsx
+++ b/src/app/work/page.tsx
@@ -3,6 +3,7 @@
 import { motion } from 'framer-motion';
 import Link from 'next/link';
 import { projects } from '@/lib/projects';
+import { ArrowRightIcon } from '@/components/icons/ArrowRightIcon';
 
 const container = {
   hidden: {},
@@ -219,21 +220,7 @@ export default function WorkPage() {
                       <span className="text-brand-gray-500 group-hover:text-brand-white transition-colors duration-300">
                         Case Study
                       </span>
-                      <svg
-                        width="14"
-                        height="14"
-                        fill="none"
-                        viewBox="0 0 14 14"
-                        className="text-brand-gray-500 group-hover:text-white translate-x-0 group-hover:translate-x-1 transition-all duration-300"
-                      >
-                        <path
-                          d="M1 7h12M8 2l5 5-5 5"
-                          stroke="currentColor"
-                          strokeWidth="1.5"
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                        />
-                      </svg>
+                      <ArrowRightIcon className="text-brand-gray-500 group-hover:text-white translate-x-0 group-hover:translate-x-1 transition-all duration-300" />
                     </div>
                   </div>
                 </Link>
@@ -258,9 +245,7 @@ export default function WorkPage() {
             className="inline-flex items-center gap-2 bg-brand-gold text-brand-black font-medium text-sm px-7 py-3.5 rounded-sm hover:bg-brand-gold-muted transition-colors duration-300"
           >
             Let&apos;s talk
-            <svg width="14" height="14" fill="none" viewBox="0 0 14 14">
-              <path d="M1 7h12M8 2l5 5-5 5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-            </svg>
+            <ArrowRightIcon />
           </Link>
         </motion.div>
       </div>

--- a/src/components/icons/ArrowRightIcon.tsx
+++ b/src/components/icons/ArrowRightIcon.tsx
@@ -1,0 +1,15 @@
+import type { SVGProps } from 'react';
+
+export function ArrowRightIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg width="14" height="14" fill="none" viewBox="0 0 14 14" {...props}>
+      <path
+        d="M1 7h12M8 2l5 5-5 5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
🎯 **What:** Extracted the identical `ArrowRightIcon` SVG code (found 7 times across the home, work, and about pages) into a shared, reusable `<ArrowRightIcon />` component.
💡 **Why:** This resolves a code health issue by removing code duplication. Abstracting the SVG into a component ensures that any future changes to the arrow icon (e.g., color, stroke width, accessible attributes) only need to be made in one place. It improves readability by replacing a verbose inline `<svg>` block with a self-documenting `<ArrowRightIcon />` tag.
✅ **Verification:** Verified visually using a Playwright script by browsing through the affected pages (`/`, `/work`, `/about`). Confirmed via `git diff` that no styles or animations were broken (as `{...props}` are cleanly spread onto the SVG element). Made sure not to commit any generated `out/` build artifacts that previously polluted the staging area.
✨ **Result:** A cleaner, more maintainable codebase with no loss in functionality or styling.

---
*PR created automatically by Jules for task [10011926967239897073](https://jules.google.com/task/10011926967239897073) started by @wanda-OS-dev*