### PR TITLE
feat(a11y): Cmd+Enter keyboard shortcut on contact form

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -248,6 +248,12 @@ export default function ContactPage() {
                     placeholder="Tell us about your project..."
                     disabled={state === 'sending'}
                     onChange={(e) => setMessageLength(e.target.value.length)}
+                    onKeyDown={(e) => {
+                      if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+                        e.preventDefault();
+                        e.currentTarget.form?.requestSubmit();
+                      }
+                    }}
                     className="w-full bg-transparent border border-white/[0.1] text-brand-white placeholder-brand-gray-500 px-4 py-3 text-sm rounded-sm focus:outline-none focus:border-brand-gold transition-colors duration-300 resize-none disabled:opacity-50 disabled:cursor-not-allowed"
                   />
                 </div>
@@ -261,6 +267,7 @@ export default function ContactPage() {
                 <button
                   type="submit"
                   disabled={state === 'sending'}
+                  aria-keyshortcuts="Meta+Enter Control+Enter"
                   className="w-full flex items-center justify-center gap-2 bg-brand-gold text-brand-black font-medium text-sm py-3.5 rounded-sm hover:bg-brand-gold-muted transition-colors duration-300 disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   {state === 'sending' && (
@@ -286,7 +293,12 @@ export default function ContactPage() {
                       ></path>
                     </svg>
                   )}
-                  {state === 'sending' ? 'Sending...' : 'Send Message'}
+                  {state === 'sending' ? 'Sending...' : (
+                    <>
+                      Send Message
+                      <kbd className="ml-1 px-1.5 py-0.5 rounded-sm bg-black/10 text-brand-black/70 font-sans text-xs" aria-hidden="true">⌘ Enter</kbd>
+                    </>
+                  )}
                 </button>
               </form>
             )}


### PR DESCRIPTION
## Summary

- Adds `Cmd+Enter` / `Ctrl+Enter` keyboard shortcut to submit the contact form from the textarea
- Uses `requestSubmit()` (not `.submit()`) to ensure HTML validation + React `onSubmit` fires correctly
- `aria-keyshortcuts` on the submit button for screen reader discovery
- `<kbd>` visual hint with `aria-hidden="true"` to avoid duplicate announcements

Replaces #166 (closed due to merge conflict).

🤖 Generated with [Claude Code](https://claude.com/claude-code)